### PR TITLE
when child processes were erroring it was being swallowed, added listener to stderr

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,17 @@ const wfb = (service, matchersMixed) =>
       return
     }
     const docker = spawn('docker-compose', ['up', service])
+    let errorMessage
+    docker.stderr.on('data', data => {
+      errorMessage = data.toString()
+    })
+    docker.on('exit', (code, signal) => {
+      if (code) {
+        reject(new Error(errorMessage))
+      } else if (signal) {
+        reject(new Error(errorMessage))
+      }
+    })
     const once = onlyOnce()
     docker.stdout.on('data', data => {
       const line = data.toString()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wait-for-blah",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
https://stackoverflow.com/questions/44832194/catching-errors-from-spawned-node-js-process

because a message to stderr is not necessarily indicative of an error, I'm capturing the messages, but only throwing an error if the process exits with a non-0 code or signal